### PR TITLE
Add AlignedConditioning & CheckpointSaveCustom

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -7,7 +7,9 @@ node_list = [ #Add list of .py files containing nodes here
     "sampler_rescalecfg",
     "sampler_tonemap",
     "sampler_tonemap_rescalecfg",
-    "sdxl_model_merging"
+    "sdxl_model_merging",
+    "model_save_custom",
+    "aligned_cond",
 ]
 
 NODE_CLASS_MAPPINGS = {}

--- a/aligned_cond.py
+++ b/aligned_cond.py
@@ -11,6 +11,8 @@ te_config = {
 def get_embeddings_tag(embeddings_dict: dict) -> dict:
     embeddings_dict_tag = {}
     for key in embeddings_dict.keys():
+        if key not in te_config.keys():
+            continue
         embeddings = embeddings_dict[key]
         embeddings_dict_tag[key] = embeddings_dict_tag.get(key, [])
         for embedding in embeddings:
@@ -74,6 +76,7 @@ class AlignedConditioning(ComfyNodeABC):
             )
         
         tags = [tag.strip() for tag in text.split(sep)]
+        embeddings_dict_default = te.tokenize(sep.join(tags))
         embeddings_dict_tags = {}
         for tag in tags:
             embeddings_dict = te.tokenize(tag)
@@ -91,6 +94,9 @@ class AlignedConditioning(ComfyNodeABC):
 
         embeddings_dict_final = {}
         for key in embeddings_dict_tags.keys():
+            if key not in te_config.keys():
+                embeddings_dict_final[key] = embeddings_dict_default[key]
+                continue
             embeddings_dict_final[key] = embeddings_dict_final.get(key, [])
             sep = embeddings_dict_sep[key]
             sep_len = len(sep)

--- a/aligned_cond.py
+++ b/aligned_cond.py
@@ -1,0 +1,134 @@
+import logging
+from comfy.comfy_types import IO, ComfyNodeABC, InputTypeDict
+
+
+te_config = {
+    "l": {"start": 49406, "end": 49407, "pad": 0, 'max_tokens': 75},
+    "g": {"start": 49406, "end": 49407, "pad": 0, 'max_tokens': 75},
+}
+
+
+def get_embeddings_tag(embeddings_dict: dict) -> dict:
+    embeddings_dict_tag = {}
+    for key in embeddings_dict.keys():
+        embeddings = embeddings_dict[key]
+        embeddings_dict_tag[key] = embeddings_dict_tag.get(key, [])
+        for embedding in embeddings:
+            start = 0
+            end = 0
+            for i, (token, weight) in enumerate(embedding):
+                if token == te_config[key]["start"]:
+                    start = i
+                if (token == te_config[key]["pad"] or token == te_config[key]["end"]):
+                    end = i
+                    break
+            if (end - start) < 2:
+                continue
+            embedding_tag = embedding[start + 1 : end]
+            embeddings_dict_tag[key].append(embedding_tag)
+    
+    return embeddings_dict_tag
+
+
+class AlignedConditioning(ComfyNodeABC):
+    @classmethod
+    def INPUT_TYPES(s) -> InputTypeDict:
+        return {
+            "required": {
+                "text": (
+                    IO.STRING,
+                    {
+                        "multiline": True,
+                        "dynamicPrompts": True,
+                        "tooltip": "The text to be encoded.",
+                    },
+                ),
+                "te": (
+                    IO.CLIP,
+                    {"tooltip": "The text encoder model used for encoding the text."},
+                ),
+                "sep": (
+                    IO.STRING,
+                    {
+                        "multiline": False,
+                        "dynamicPrompts": False,
+                        "tooltip": "The tag separator.",
+                    },
+                ),
+            }
+        }
+
+    RETURN_TYPES = (IO.CONDITIONING,)
+    OUTPUT_TOOLTIPS = (
+        "A tag aligned conditioning containing the embedded text used to guide the diffusion model.",
+    )
+    FUNCTION = "encode"
+
+    CATEGORY = "custom_node_experiments"
+    DESCRIPTION = "Encodes a text prompt in a tag aligned manner using a text encoder model into an embedding that can be used to guide the diffusion model towards generating specific images."
+
+    def encode(self, te, text, sep):
+        if te is None:
+            raise RuntimeError(
+                "ERROR: TE input is invalid: None\n\nIf the TE is from a checkpoint loader node your checkpoint does not contain a valid text encoder model."
+            )
+        
+        tags = [tag.strip() for tag in text.split(sep)]
+        embeddings_dict_tags = {}
+        for tag in tags:
+            embeddings_dict = te.tokenize(tag)
+            for key in embeddings_dict.keys():
+                embeddings_dict_tags[key] = embeddings_dict_tags.get(key, [])
+            embeddings_dict_tag = get_embeddings_tag(embeddings_dict)
+            for key in embeddings_dict_tags:
+                embeddings_dict_tags[key].extend(embeddings_dict_tag.get(key, []))
+        
+        embeddings_dict_sep = {}
+        embeddings_dict = te.tokenize(sep)
+        embeddings_dict_sep_full = get_embeddings_tag(embeddings_dict)
+        for key in embeddings_dict:
+            embeddings_dict_sep[key] = (embeddings_dict_sep_full.get(key, [[]]))[0]
+
+        embeddings_dict_final = {}
+        for key in embeddings_dict_tags.keys():
+            embeddings_dict_final[key] = embeddings_dict_final.get(key, [])
+            sep = embeddings_dict_sep[key]
+            sep_len = len(sep)
+            batch = []
+            for embedding_tag in embeddings_dict_tags[key]:
+                if len(batch)==0:
+                    if len(embedding_tag) <= te_config[key]['max_tokens']:
+                        batch.extend(embedding_tag)
+                    else:
+                        logging.warning('WARNING: Tag embedding too long, ignoring')
+                else:
+                    if len(batch) + sep_len + len(embedding_tag) <= te_config[key]['max_tokens']:
+                        batch.extend(sep)
+                        batch.extend(embedding_tag)
+                    else:
+                        if len(batch)<te_config[key]['max_tokens']:
+                            batch.extend([(te_config[key]['pad'], 1.0)]*(te_config[key]['max_tokens']-len(batch)))
+                        batch_final = [(te_config[key]['start'], 1.0)] + batch + [(te_config[key]['end'], 1.0)]
+                        embeddings_dict_final[key].append(batch_final)
+                        batch = []
+                        if len(embedding_tag) <= te_config[key]['max_tokens']:
+                            batch.extend(embedding_tag)
+                        else:
+                            logging.warning('WARNING: Tag embedding too long, ignoring')
+
+            if len(batch)>0:
+                batch.extend([(te_config[key]['pad'], 1.0)]*(te_config[key]['max_tokens']-len(batch)))
+                batch_final = [(te_config[key]['start'], 1.0)] + batch + [(te_config[key]['end'], 1.0)]
+                embeddings_dict_final[key].append(batch_final)
+
+        for key in embeddings_dict_final.keys():
+            if len(embeddings_dict_final[key])==0:
+                batch_final = [(te_config[key]['start'], 1.0)] + ([(te_config[key]['pad'], 1.0)]*te_config[key]['max_tokens']) + [(te_config[key]['end'], 1.0)]
+                embeddings_dict_final[key].append(batch_final)
+
+        return (te.encode_from_tokens_scheduled(embeddings_dict_final), )
+
+
+NODE_CLASS_MAPPINGS = {
+    "AlignedConditioning": AlignedConditioning,
+}

--- a/model_save_custom.py
+++ b/model_save_custom.py
@@ -1,0 +1,117 @@
+import comfy.utils
+import comfy.model_base
+import comfy.model_management
+
+import folder_paths
+
+import torch
+import os
+
+
+def save_checkpoint_custom(output_path, model, clip=None, vae=None, clip_vision=None, save_precision='float16', metadata=None, extra_keys={}):
+    clip_sd = None
+    load_models = [model]
+    if clip is not None:
+        load_models.append(clip.load_model())
+        clip_sd = clip.get_sd()
+    vae_sd = None
+    if vae is not None:
+        vae_sd = vae.get_sd()
+
+    comfy.model_management.load_models_gpu(load_models, force_patch_weights=True)
+    clip_vision_sd = clip_vision.get_sd() if clip_vision is not None else None
+    sd = model.model.state_dict_for_saving(clip_sd, vae_sd, clip_vision_sd)
+    for k in extra_keys:
+        sd[k] = extra_keys[k]
+
+    for k in sd:
+        t = sd[k]
+        if not t.is_contiguous():
+            sd[k] = t.contiguous()
+    
+    match save_precision:
+        case 'float16':
+            sd = comfy.utils.convert_sd_to(sd, torch.float16)
+        case 'bfloat16':
+            sd = comfy.utils.convert_sd_to(sd, torch.bfloat16)
+        case 'float32':
+            sd = comfy.utils.convert_sd_to(sd, torch.float32)
+        case 'no change':
+            sd = sd
+        case _:
+            sd = comfy.utils.convert_sd_to(sd, torch.float16)
+    
+    comfy.utils.save_torch_file(sd, output_path, metadata=metadata)
+
+
+class CheckpointSaveCustom:
+    def __init__(self):
+        self.output_dir = folder_paths.get_output_directory()
+
+    @classmethod
+    def INPUT_TYPES(s):
+        return {"required": { "model": ("MODEL",),
+                              "clip": ("CLIP",),
+                              "vae": ("VAE",),
+                              "filename_prefix": ("STRING", {"default": "checkpoints/ComfyUI"}),
+                              "filename_prefix": ("STRING", {"default": "checkpoints/ComfyUI"}),
+                              "architecture": ("STRING", {"default": "stable-diffusion-xl-v1-base"}),
+                              "title": ("STRING", {"default": "Custom model"}),
+                              "author": ("STRING", {"default": "Anonymous"}),
+                              "description": ("STRING", {"default": "A custom model"}),
+                              "date": ("STRING", {"default": "2025-01-01"}),
+                              "license": ("STRING", {"default": "Fair AI Public License 1.0-SD"}),
+                              "predict_key": (['eps', 'v_pred', 'x0'], ),
+                              "ztSNR": ("BOOLEAN", ),
+                              "save_precision": (['float16', 'bfloat16', 'float32', 'no change'], ),
+                            },
+                "hidden": {"prompt": "PROMPT", "extra_pnginfo": "EXTRA_PNGINFO"},}
+    RETURN_TYPES = ()
+    FUNCTION = "save"
+    OUTPUT_NODE = True
+
+    CATEGORY = "advanced/model_merging"
+
+    def save(self, model, clip, vae, filename_prefix, architecture, title, author, description, date, license, predict_key, ztSNR, save_precision, prompt=None, extra_pnginfo=None):
+        full_output_folder, filename, counter, subfolder, filename_prefix = folder_paths.get_save_image_path(filename_prefix, self.output_dir)
+        
+        metadata = {}
+
+        metadata["modelspec.sai_model_spec"] = "1.0.0"
+        metadata["modelspec.architecture"] = architecture
+        metadata["modelspec.implementation"] = "sgm"
+        metadata["modelspec.title"] = title
+        
+        metadata["modelspec.author"] = author
+        metadata["modelspec.description"] = description
+        metadata["modelspec.date"] = date
+
+        metadata["modelspec.license"] = license
+
+        extra_keys = {}
+        extra_keys[predict_key] = torch.tensor([])
+        if ztSNR:
+            extra_keys['ztsnr'] = torch.tensor([])
+        
+        model_sampling = model.get_model_object("model_sampling")
+        if isinstance(model_sampling, comfy.model_sampling.ModelSamplingContinuousEDM):
+            metadata["modelspec.implementation"] = "edm"
+            if isinstance(model_sampling, comfy.model_sampling.V_PREDICTION):
+                extra_keys["edm_vpred.sigma_max"] = torch.tensor(model_sampling.sigma_max).float()
+                extra_keys["edm_vpred.sigma_min"] = torch.tensor(model_sampling.sigma_min).float()
+
+        if model.model.model_type == comfy.model_base.ModelType.EPS:
+            metadata["modelspec.predict_key"] = "epsilon"
+        elif model.model.model_type == comfy.model_base.ModelType.V_PREDICTION:
+            metadata["modelspec.predict_key"] = "v"
+
+        output_checkpoint = f"{filename}_{counter:05}_.safetensors"
+        output_checkpoint = os.path.join(full_output_folder, output_checkpoint)
+        
+        save_checkpoint_custom(output_checkpoint, model, clip, vae, clip_vision=None, save_precision=save_precision, metadata=metadata, extra_keys=extra_keys)
+        return {}
+
+
+NODE_CLASS_MAPPINGS = {
+    "CheckpointSaveCustom": CheckpointSaveCustom,
+}


### PR DESCRIPTION
> AlignedConditioning
- For tag based prompting
- Split tags with the user defined separator and tokenize them individually
- Prevents splitting of tag across embeddings
- Uses zero padding to fill out each embedding
- Currently supports CLIP L and CLIP G
- Embeddings are not supported

>CheckpointSaveCustom
- User defined ModelSpec metadata
- User defined save data type